### PR TITLE
Fixed Param Typo in `WriteableContainerInterface`

### DIFF
--- a/src/WritableContainerInterface.php
+++ b/src/WritableContainerInterface.php
@@ -29,7 +29,7 @@ interface WritableContainerInterface extends ContainerInterface
      *
      * @since 0.1
      *
-     * @param BaseServiceProviderInterface $serviceProvieder The provider to register.
+     * @param BaseServiceProviderInterface $serviceProvider The provider to register.
      */
-    public function register(BaseServiceProviderInterface $serviceProvieder);
+    public function register(BaseServiceProviderInterface $serviceProvider);
 }


### PR DESCRIPTION
Fixed the parameter name from `$serviceProvieder` to `$serviceProvider`.

This is a solution for issue #4.